### PR TITLE
Add product CRUD using Prisma

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ Run the dev server:
 npm run dev
 ```
 
+Before starting the dev server the first time, install dependencies and generate the Prisma client:
+
+```sh
+npm install
+npx prisma generate
+```
+
 ## Deployment
 
 First, build your app for production:

--- a/app/components/ui/button.tsx
+++ b/app/components/ui/button.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "~/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement>, VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(({ className, variant, size, asChild = false, ...props }, ref) => {
+  const Comp = asChild ? Slot : "button";
+  return <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />;
+});
+Button.displayName = "Button";
+
+export { Button, buttonVariants };

--- a/app/db.server.ts
+++ b/app/db.server.ts
@@ -1,0 +1,21 @@
+import { PrismaClient } from "@prisma/client";
+
+let prisma: PrismaClient;
+
+declare global {
+// eslint-disable-next-line no-var
+  var __db: PrismaClient | undefined;
+}
+
+if (process.env.NODE_ENV === "production") {
+  prisma = new PrismaClient();
+  prisma.$connect();
+} else {
+  if (!global.__db) {
+    global.__db = new PrismaClient();
+    global.__db.$connect();
+  }
+  prisma = global.__db;
+}
+
+export { prisma };

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,4 +1,5 @@
 import {
+  Link,
   Links,
   Meta,
   Outlet,
@@ -32,7 +33,13 @@ export function Layout({ children }: { children: React.ReactNode }) {
         <Links />
       </head>
       <body>
-        {children}
+        <header className="border-b p-4">
+          <nav className="container mx-auto flex gap-4">
+            <Link to="/" className="font-bold">Home</Link>
+            <Link to="/products">Products</Link>
+          </nav>
+        </header>
+        <main className="container mx-auto py-4">{children}</main>
         <ScrollRestoration />
         <Scripts />
       </body>

--- a/app/routes/products.$id.edit.tsx
+++ b/app/routes/products.$id.edit.tsx
@@ -1,0 +1,45 @@
+import { ActionFunctionArgs, LoaderFunctionArgs, json, redirect } from "@remix-run/node";
+import { Form, useLoaderData } from "@remix-run/react";
+import { prisma } from "~/db.server";
+import { Button } from "~/components/ui/button";
+
+export async function loader({ params }: LoaderFunctionArgs) {
+  const id = Number(params.id);
+  const product = await prisma.product.findUnique({ where: { id } });
+  if (!product) throw new Response("Not Found", { status: 404 });
+  return json({ product });
+}
+
+export async function action({ request, params }: ActionFunctionArgs) {
+  const id = Number(params.id);
+  const formData = await request.formData();
+  const name = String(formData.get("name"));
+  const price = parseFloat(String(formData.get("price")));
+  const description = formData.get("description") as string | null;
+  await prisma.product.update({ where: { id }, data: { name, price, description } });
+  return redirect("/products");
+}
+
+export default function EditProduct() {
+  const { product } = useLoaderData<typeof loader>();
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Edit Product</h1>
+      <Form method="post" className="space-y-4 max-w-sm">
+        <div>
+          <label className="block text-sm font-medium mb-1" htmlFor="name">Name</label>
+          <input id="name" name="name" defaultValue={product.name} className="w-full border p-2 rounded" required />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1" htmlFor="price">Price</label>
+          <input id="price" name="price" type="number" step="0.01" defaultValue={product.price} className="w-full border p-2 rounded" required />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1" htmlFor="description">Description</label>
+          <textarea id="description" name="description" defaultValue={product.description ?? ''} className="w-full border p-2 rounded" />
+        </div>
+        <Button type="submit">Update</Button>
+      </Form>
+    </div>
+  );
+}

--- a/app/routes/products.new.tsx
+++ b/app/routes/products.new.tsx
@@ -1,0 +1,36 @@
+import { ActionFunctionArgs, redirect } from "@remix-run/node";
+import { Form } from "@remix-run/react";
+import { prisma } from "~/db.server";
+import { Button } from "~/components/ui/button";
+
+export async function action({ request }: ActionFunctionArgs) {
+  const formData = await request.formData();
+  const name = String(formData.get("name"));
+  const price = parseFloat(String(formData.get("price")));
+  const description = formData.get("description") as string | null;
+  await prisma.product.create({ data: { name, price, description } });
+  return redirect("/products");
+}
+
+export default function NewProduct() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">New Product</h1>
+      <Form method="post" className="space-y-4 max-w-sm">
+        <div>
+          <label className="block text-sm font-medium mb-1" htmlFor="name">Name</label>
+          <input id="name" name="name" className="w-full border p-2 rounded" required />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1" htmlFor="price">Price</label>
+          <input id="price" name="price" type="number" step="0.01" className="w-full border p-2 rounded" required />
+        </div>
+        <div>
+          <label className="block text-sm font-medium mb-1" htmlFor="description">Description</label>
+          <textarea id="description" name="description" className="w-full border p-2 rounded" />
+        </div>
+        <Button type="submit">Create</Button>
+      </Form>
+    </div>
+  );
+}

--- a/app/routes/products.tsx
+++ b/app/routes/products.tsx
@@ -1,0 +1,57 @@
+import { ActionFunctionArgs, json, redirect } from "@remix-run/node";
+import { Form, Link, useLoaderData } from "@remix-run/react";
+import { prisma } from "~/db.server";
+import { Button } from "~/components/ui/button";
+
+export async function loader() {
+  const products = await prisma.product.findMany({ orderBy: { id: "desc" } });
+  return json({ products });
+}
+
+export async function action({ request }: ActionFunctionArgs) {
+  const formData = await request.formData();
+  const intent = formData.get("intent");
+  if (intent === "delete") {
+    const id = Number(formData.get("id"));
+    if (id) {
+      await prisma.product.delete({ where: { id } });
+    }
+    return redirect("/products");
+  }
+  return null;
+}
+
+export default function Products() {
+  const { products } = useLoaderData<typeof loader>();
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold">Products</h1>
+        <Button asChild>
+          <Link to="/products/new">New Product</Link>
+        </Button>
+      </div>
+      <ul className="space-y-2">
+        {products.map((p) => (
+          <li key={p.id} className="border p-2 rounded flex justify-between items-center">
+            <div>
+              <p className="font-semibold">{p.name}</p>
+              <p className="text-sm text-gray-500">${p.price.toFixed(2)}</p>
+            </div>
+            <div className="flex gap-2">
+              <Button variant="outline" asChild>
+                <Link to={`/products/${p.id}/edit`}>Edit</Link>
+              </Button>
+              <Form method="post">
+                <input type="hidden" name="id" value={p.id} />
+                <Button type="submit" name="intent" value="delete" variant="destructive">
+                  Delete
+                </Button>
+              </Form>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,12 +6,18 @@
     "": {
       "name": "books",
       "dependencies": {
+        "@prisma/client": "^6.9.0",
+        "@radix-ui/react-slot": "^1.2.3",
         "@remix-run/node": "^2.16.7",
         "@remix-run/react": "^2.16.7",
         "@remix-run/serve": "^2.16.7",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
         "isbot": "^4.1.0",
+        "lucide-react": "^0.513.0",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "tailwind-merge": "^3.3.0"
       },
       "devDependencies": {
         "@remix-run/dev": "^2.16.7",
@@ -27,6 +33,7 @@
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
         "postcss": "^8.4.38",
+        "prisma": "^6.9.0",
         "tailwindcss": "^3.4.4",
         "typescript": "^5.1.6",
         "vite": "^6.0.0",
@@ -1457,6 +1464,131 @@
         "node": ">=14"
       }
     },
+    "node_modules/@prisma/client": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.9.0.tgz",
+      "integrity": "sha512-Gg7j1hwy3SgF1KHrh0PZsYvAaykeR0PaxusnLXydehS96voYCGt1U5zVR31NIouYc63hWzidcrir1a7AIyCsNQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/config": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.9.0.tgz",
+      "integrity": "sha512-Wcfk8/lN3WRJd5w4jmNQkUwhUw0eksaU/+BlAJwPQKW10k0h0LC9PD/6TQFmqKVbHQL0vG2z266r0S1MPzzhbA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jiti": "2.4.2"
+      }
+    },
+    "node_modules/@prisma/config/node_modules/jiti": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
+      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "devOptional": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.9.0.tgz",
+      "integrity": "sha512-bFeur/qi/Q+Mqk4JdQ3R38upSYPebv5aOyD1RKywVD+rAMLtRkmTFn28ZuTtVOnZHEdtxnNOCH+bPIeSGz1+Fg==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.9.0.tgz",
+      "integrity": "sha512-im0X0bwDLA0244CDf8fuvnLuCQcBBdAGgr+ByvGfQY9wWl6EA+kRGwVk8ZIpG65rnlOwtaWIr/ZcEU5pNVvq9g==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.9.0",
+        "@prisma/engines-version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
+        "@prisma/fetch-engine": "6.9.0",
+        "@prisma/get-platform": "6.9.0"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e.tgz",
+      "integrity": "sha512-Qp9gMoBHgqhKlrvumZWujmuD7q4DV/gooEyPCLtbkc13EZdSz2RsGUJ5mHb3RJgAbk+dm6XenqG7obJEhXcJ6Q==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.9.0.tgz",
+      "integrity": "sha512-PMKhJdl4fOdeE3J3NkcWZ+tf3W6rx3ht/rLU8w4SXFRcLhd5+3VcqY4Kslpdm8osca4ej3gTfB3+cSk5pGxgFg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.9.0",
+        "@prisma/engines-version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
+        "@prisma/get-platform": "6.9.0"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.9.0.tgz",
+      "integrity": "sha512-/B4n+5V1LI/1JQcHp+sUpyRT1bBgZVPHbsC4lt4/19Xp4jvNIVcq5KYNtQDk5e/ukTSjo9PZVAxxy9ieFtlpTQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.9.0"
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+      "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@remix-run/dev": {
       "version": "2.16.8",
       "resolved": "https://registry.npmjs.org/@remix-run/dev/-/dev-2.16.8.tgz",
@@ -2138,14 +2270,14 @@
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
       "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.23",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
       "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -4128,6 +4260,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -4172,6 +4316,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -4388,7 +4541,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -7753,6 +7906,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.513.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.513.0.tgz",
+      "integrity": "sha512-CJZKq2g8Y8yN4Aq002GahSXbG2JpFv9kXwyiOAMvUBv7pxeOFHUWKB0mO7MiY4ZVFCV4aNjv2BJFq/z3DgKPQg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/markdown-extensions": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/markdown-extensions/-/markdown-extensions-1.1.1.tgz",
@@ -10066,6 +10228,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/prisma": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.9.0.tgz",
+      "integrity": "sha512-resJAwMyZREC/I40LF6FZ6rZTnlrlrYrb63oW37Gq+U+9xHwbyMSPJjKtM7VZf3gTO86t/Oyz+YeSXr3CmAY1Q==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/config": "6.9.0",
+        "@prisma/engines": "6.9.0"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/proc-log": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-3.0.0.tgz",
@@ -11542,6 +11730,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.0.tgz",
+      "integrity": "sha512-fyW/pEfcQSiigd5SNn0nApUOxx0zB/dm6UDU/rEwc2c3sX2smWUNbapHv+QRqLGVp9GWX3THIa7MUGPo+YkDzQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -11,12 +11,18 @@
     "typecheck": "tsc"
   },
   "dependencies": {
+    "@prisma/client": "^6.9.0",
+    "@radix-ui/react-slot": "^1.2.3",
     "@remix-run/node": "^2.16.7",
     "@remix-run/react": "^2.16.7",
     "@remix-run/serve": "^2.16.7",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
     "isbot": "^4.1.0",
+    "lucide-react": "^0.513.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "tailwind-merge": "^3.3.0"
   },
   "devDependencies": {
     "@remix-run/dev": "^2.16.7",
@@ -32,6 +38,7 @@
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "postcss": "^8.4.38",
+    "prisma": "^6.9.0",
     "tailwindcss": "^3.4.4",
     "typescript": "^5.1.6",
     "vite": "^6.0.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,17 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model Product {
+  id          Int      @id @default(autoincrement())
+  name        String
+  description String?
+  price       Float
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+}


### PR DESCRIPTION
## Summary
- set up Prisma with postgres database
- add shadcn-inspired button component
- implement product CRUD routes
- add navigation layout
- document Prisma generate step

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6840853d13788332879bb3631d243cd2